### PR TITLE
refactor(es modules): migrate project to ESM (ES Modules)

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,9 +1,0 @@
-module.exports = {
-  semi: false,
-  singleQuote: true,
-  jsxSingleQuote: true,
-  printWidth: 80,
-  useTabs: false,
-  tabWidth: 2,
-  endOfLine: 'lf',
-}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "jsxSingleQuote": true,
+  "printWidth": 80,
+  "useTabs": false,
+  "tabWidth": 2,
+  "endOfLine": "lf"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig([
     files: ['**/*.js', '**/*.ts'],
     rules: {
       'no-underscore-dangle': ['error', { allow: ['_id'] }],
+      'import-x/extensions': 'off',
     },
   },
 ])

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.2.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "dev": "tsx watch src/app/app.js",
-    "start": "node dist/app/app.js",
+    "dev": "tsx watch src/main.js",
+    "start": "node dist/main.js",
     "test": "",
     "build": "tsc",
     "lint": "eslint --fix",

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,50 +1,57 @@
-const { errors } = require('celebrate')
-const cookieParser = require('cookie-parser')
-const express = require('express')
-const helmet = require('helmet')
-const mongoose = require('mongoose')
+import { errors } from 'celebrate'
+import cookieParser from 'cookie-parser'
+import express from 'express'
+import helmet from 'helmet'
+import mongoose from 'mongoose'
 
-const router = require('./routes')
-const { MONGODB_URI, PORT } = require('../shared/config/env')
-const { INTERNAL_SERVER_ERROR } = require('../shared/constants/response')
-const cors = require('../shared/middlewares/cors')
-const { limiter } = require('../shared/middlewares/limiter')
-const { errorLogger, requestLogger } = require('../shared/middlewares/logger')
+import router from './routes.js'
+import config from '../shared/config/env.js'
+import response from '../shared/constants/response.js'
+import cors from '../shared/middlewares/cors.js'
+import limiter from '../shared/middlewares/limiter.js'
+import { errorLogger, requestLogger } from '../shared/middlewares/logger.js'
 
-const app = express()
+const { MONGODB_URI } = config
+const { INTERNAL_SERVER_ERROR } = response
 
-app.use(helmet())
+const createApp = () => {
+  const app = express()
 
-app.use(cors)
+  app.use(helmet())
 
-app.use(limiter)
+  app.use(cors)
 
-app.use(cookieParser())
+  app.use(limiter)
 
-mongoose.connect(`${MONGODB_URI}`)
+  app.use(cookieParser())
 
-app.use(express.json())
-app.use(express.urlencoded({ extended: true }))
+  mongoose.connect(`${MONGODB_URI}`)
 
-app.use(requestLogger)
+  app.use(express.json())
+  app.use(express.urlencoded({ extended: true }))
 
-app.use(router)
+  app.use(requestLogger)
 
-app.use(errorLogger)
+  app.use(router)
 
-app.use(errors())
+  app.use(errorLogger)
 
-app.use((err, req, res, next) => {
-  console.log(err)
-  const { statusCode = INTERNAL_SERVER_ERROR.statusCode, message } = err
+  app.use(errors())
 
-  res.status(statusCode).send({
-    message:
-      statusCode === INTERNAL_SERVER_ERROR.statusCode
-        ? INTERNAL_SERVER_ERROR.text
-        : message,
+  app.use((err, req, res, next) => {
+    console.log(err)
+    const { statusCode = INTERNAL_SERVER_ERROR.statusCode, message } = err
+
+    res.status(statusCode).send({
+      message:
+        statusCode === INTERNAL_SERVER_ERROR.statusCode
+          ? INTERNAL_SERVER_ERROR.text
+          : message,
+    })
+    next()
   })
-  next()
-})
 
-return app.listen(PORT)
+  return app
+}
+
+export default createApp

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -1,19 +1,18 @@
-const router = require('express').Router()
+import { Router } from 'express'
 
-const moviesRoutes = require('../modules/movies/movies.routes')
-const {
-  createUser,
-  login,
-  logout,
-} = require('../modules/user/users.controller')
-const usersRoutes = require('../modules/user/users.routes')
-const { NOT_FOUND } = require('../shared/constants/response')
-const NotFoundError = require('../shared/errors/notFound')
-const auth = require('../shared/middlewares/auth')
-const {
+import moviesRoutes from '../modules/movies/movies.routes.js'
+import { createUser, login, logout } from '../modules/user/users.controller.js'
+import usersRoutes from '../modules/user/users.routes.js'
+import response from '../shared/constants/response.js'
+import NotFoundError from '../shared/errors/notFound.js'
+import auth from '../shared/middlewares/auth.js'
+import {
   signinValidation,
   signupValidationd,
-} = require('../shared/middlewares/validation')
+} from '../shared/middlewares/validation.js'
+
+const router = Router()
+const { NOT_FOUND } = response
 
 router.post('/signin', signinValidation, login)
 
@@ -30,4 +29,4 @@ router.use((req, res, next) => {
   next(new NotFoundError(NOT_FOUND.text))
 })
 
-module.exports = router
+export default router

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+import createApp from './app/app.js'
+import config from './shared/config/env.js'
+
+const { PORT } = config
+
+const app = createApp()
+app.listen(PORT)

--- a/src/modules/movies/movie.model.js
+++ b/src/modules/movies/movie.model.js
@@ -1,13 +1,11 @@
-const mongoose = require('mongoose')
-const validator = require('validator')
+import mongoose from 'mongoose'
+import validator from 'validator'
 
-const {
-  BAD_REQUEST,
-  FORBIDDEN,
-  NOT_FOUND,
-} = require('../../shared/constants/response')
-const Forbidden = require('../../shared/errors/forbidden')
-const NotFoundError = require('../../shared/errors/notFound')
+import response from '../../shared/constants/response.js'
+import Forbidden from '../../shared/errors/forbidden.js'
+import NotFoundError from '../../shared/errors/notFound.js'
+
+const { BAD_REQUEST, FORBIDDEN, NOT_FOUND } = response
 
 const movieSchema = new mongoose.Schema({
   country: {
@@ -92,4 +90,4 @@ movieSchema.statics.deleteMovieByCredentials =
     })
   }
 
-module.exports = mongoose.model('movie', movieSchema)
+export default mongoose.model('movie', movieSchema)

--- a/src/modules/movies/movies.controller.js
+++ b/src/modules/movies/movies.controller.js
@@ -1,8 +1,10 @@
-const Movie = require('./movie.model')
-const { BAD_REQUEST, CREATED, OK } = require('../../shared/constants/response')
-const BadRequestError = require('../../shared/errors/badRequest')
+import Movie from './movie.model.js'
+import response from '../../shared/constants/response.js'
+import BadRequestError from '../../shared/errors/badRequest.js'
 
-module.exports.addMovie = (req, res, next) => {
+const { CREATED, BAD_REQUEST, OK } = response
+
+export const addMovie = (req, res, next) => {
   const {
     country,
     director,
@@ -44,7 +46,7 @@ module.exports.addMovie = (req, res, next) => {
     })
 }
 
-module.exports.deleteMovieByCredentials = (req, res, next) => {
+export const deleteMovieByCredentials = (req, res, next) => {
   Movie.deleteMovieByCredentials(req.params.movieId, req.user._id)
     .then((movie) => res.status(OK.statusCode).send(movie))
     .catch((err) => {
@@ -54,7 +56,7 @@ module.exports.deleteMovieByCredentials = (req, res, next) => {
       return next(err)
     })
 }
-module.exports.getMovies = (req, res, next) => {
+export const getMovies = (req, res, next) => {
   Movie.find({})
     .populate('owner')
     .then((movies) => res.status(OK.statusCode).send(movies))

--- a/src/modules/movies/movies.routes.js
+++ b/src/modules/movies/movies.routes.js
@@ -1,14 +1,16 @@
-const router = require('express').Router()
+import { Router } from 'express'
 
-const {
+import {
   addMovie,
   deleteMovieByCredentials,
   getMovies,
-} = require('./movies.controller')
-const {
+} from './movies.controller.js'
+import {
   addMovieValidation,
   deleteMovieValidation,
-} = require('../../shared/middlewares/validation')
+} from '../../shared/middlewares/validation.js'
+
+const router = Router()
 
 router.get('/', getMovies)
 
@@ -16,4 +18,4 @@ router.post('/', addMovieValidation, addMovie)
 
 router.delete('/:movieId', deleteMovieValidation, deleteMovieByCredentials)
 
-module.exports = router
+export default router

--- a/src/modules/user/users.controller.js
+++ b/src/modules/user/users.controller.js
@@ -1,20 +1,17 @@
-const bcrypt = require('bcryptjs')
-const jwt = require('jsonwebtoken')
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
 
-const User = require('./users.model')
-const { JWT_SECRET } = require('../../shared/config/env')
-const {
-  BAD_REQUEST,
-  CONFLICT,
-  CREATED,
-  NOT_FOUND,
-  OK,
-} = require('../../shared/constants/response')
-const BadRequestError = require('../../shared/errors/badRequest')
-const Conflict = require('../../shared/errors/conflict')
-const NotFoundError = require('../../shared/errors/notFound')
+import User from './users.model.js'
+import config from '../../shared/config/env.js'
+import response from '../../shared/constants/response.js'
+import BadRequestError from '../../shared/errors/badRequest.js'
+import Conflict from '../../shared/errors/conflict.js'
+import NotFoundError from '../../shared/errors/notFound.js'
 
-module.exports.createUser = (req, res, next) => {
+const { JWT_SECRET } = config
+const { BAD_REQUEST, CONFLICT, CREATED, NOT_FOUND, OK } = response
+
+export const createUser = (req, res, next) => {
   bcrypt.hash(req.body.password, 10).then((hash) =>
     User.create({
       name: req.body.name,
@@ -35,7 +32,7 @@ module.exports.createUser = (req, res, next) => {
       }),
   )
 }
-module.exports.getUserProfile = (req, res, next) => {
+export const getUserProfile = (req, res, next) => {
   User.findById(req.user._id)
     .then((user) => {
       if (!user) {
@@ -51,7 +48,7 @@ module.exports.getUserProfile = (req, res, next) => {
     })
 }
 
-module.exports.login = (req, res, next) => {
+export const login = (req, res, next) => {
   const { email, password } = req.body
 
   return User.findUserByCredentials(email, password)
@@ -70,9 +67,9 @@ module.exports.login = (req, res, next) => {
     .catch(next)
 }
 
-module.exports.logout = (req, res) =>
+export const logout = (req, res) =>
   res.status(OK.statusCode).clearCookie('token').send({})
-module.exports.updateUserProfile = (req, res, next) => {
+export const updateUserProfile = (req, res, next) => {
   const { name, email } = req.body
 
   User.findByIdAndUpdate(

--- a/src/modules/user/users.model.js
+++ b/src/modules/user/users.model.js
@@ -1,9 +1,11 @@
-const bcrypt = require('bcryptjs')
-const mongoose = require('mongoose')
-const validator = require('validator')
+import bcrypt from 'bcryptjs'
+import mongoose from 'mongoose'
+import validator from 'validator'
 
-const { BAD_REQUEST, UNAUTHORIZED } = require('../../shared/constants/response')
-const Unauthorized = require('../../shared/errors/unauthorized')
+import response from '../../shared/constants/response.js'
+import Unauthorized from '../../shared/errors/unauthorized.js'
+
+const { BAD_REQUEST, UNAUTHORIZED } = response
 
 const userSchema = new mongoose.Schema({
   email: {
@@ -56,4 +58,4 @@ userSchema.statics.findUserByCredentials = function findUserByCredentials(
     .catch()
 }
 
-module.exports = mongoose.model('user', userSchema)
+export default mongoose.model('user', userSchema)

--- a/src/modules/user/users.routes.js
+++ b/src/modules/user/users.routes.js
@@ -1,12 +1,12 @@
-const router = require('express').Router()
+import { Router } from 'express'
 
-const { getUserProfile, updateUserProfile } = require('./users.controller')
-const {
-  updateUserProfileValidation,
-} = require('../../shared/middlewares/validation')
+import { getUserProfile, updateUserProfile } from './users.controller.js'
+import { updateUserProfileValidation } from '../../shared/middlewares/validation.js'
+
+const router = Router()
 
 router.get('/me', getUserProfile)
 
 router.patch('/me', updateUserProfileValidation, updateUserProfile)
 
-module.exports = router
+export default router

--- a/src/shared/config/env.js
+++ b/src/shared/config/env.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+import 'dotenv/config'
 
 const { NODE_ENV, PORT, JWT_SECRET, MONGODB_URI, FRONTEND_URL } = process.env
 
@@ -16,4 +16,4 @@ const config = {
       : 'http://localhost:3000',
 }
 
-module.exports = config
+export default config

--- a/src/shared/constants/response.js
+++ b/src/shared/constants/response.js
@@ -31,4 +31,4 @@ const response = {
   },
 }
 
-module.exports = response
+export default response

--- a/src/shared/errors/badRequest.js
+++ b/src/shared/errors/badRequest.js
@@ -1,4 +1,6 @@
-const { BAD_REQUEST } = require('../constants/response')
+import response from '../constants/response.js'
+
+const { BAD_REQUEST } = response
 
 class BadRequestError extends Error {
   constructor(message) {
@@ -7,4 +9,4 @@ class BadRequestError extends Error {
   }
 }
 
-module.exports = BadRequestError
+export default BadRequestError

--- a/src/shared/errors/conflict.js
+++ b/src/shared/errors/conflict.js
@@ -1,4 +1,6 @@
-const { CONFLICT } = require('../constants/response')
+import response from '../constants/response.js'
+
+const { CONFLICT } = response
 
 class Conflict extends Error {
   constructor(message) {
@@ -7,4 +9,4 @@ class Conflict extends Error {
   }
 }
 
-module.exports = Conflict
+export default Conflict

--- a/src/shared/errors/forbidden.js
+++ b/src/shared/errors/forbidden.js
@@ -1,4 +1,6 @@
-const { FORBIDDEN } = require('../constants/response')
+import response from '../constants/response.js'
+
+const { FORBIDDEN } = response
 
 class Forbidden extends Error {
   constructor(message) {
@@ -7,4 +9,4 @@ class Forbidden extends Error {
   }
 }
 
-module.exports = Forbidden
+export default Forbidden

--- a/src/shared/errors/notFound.js
+++ b/src/shared/errors/notFound.js
@@ -1,4 +1,6 @@
-const { NOT_FOUND } = require('../constants/response')
+import response from '../constants/response.js'
+
+const { NOT_FOUND } = response
 
 class NotFoundError extends Error {
   constructor(message) {
@@ -7,4 +9,4 @@ class NotFoundError extends Error {
   }
 }
 
-module.exports = NotFoundError
+export default NotFoundError

--- a/src/shared/errors/unauthorized.js
+++ b/src/shared/errors/unauthorized.js
@@ -1,4 +1,6 @@
-const { UNAUTHORIZED } = require('../constants/response')
+import response from '../constants/response.js'
+
+const { UNAUTHORIZED } = response
 
 class Unauthorized extends Error {
   constructor(message) {
@@ -7,4 +9,4 @@ class Unauthorized extends Error {
   }
 }
 
-module.exports = Unauthorized
+export default Unauthorized

--- a/src/shared/middlewares/auth.js
+++ b/src/shared/middlewares/auth.js
@@ -1,10 +1,13 @@
-const jwt = require('jsonwebtoken')
+import jwt from 'jsonwebtoken'
 
-const { JWT_SECRET } = require('../config/env')
-const { FORBIDDEN } = require('../constants/response')
-const Forbidden = require('../errors/forbidden')
+import config from '../config/env.js'
+import response from '../constants/response.js'
+import Forbidden from '../errors/forbidden.js'
 
-module.exports = (req, res, next) => {
+const { JWT_SECRET } = config
+const { FORBIDDEN } = response
+
+const auth = (req, _, next) => {
   const { token } = req.cookies
 
   if (!token) {
@@ -22,3 +25,5 @@ module.exports = (req, res, next) => {
   req.user = payload
   return next()
 }
+
+export default auth

--- a/src/shared/middlewares/cors.js
+++ b/src/shared/middlewares/cors.js
@@ -1,9 +1,11 @@
-const { FRONTEND_URL } = require('../config/env')
+import config from '../config/env.js'
+
+const { FRONTEND_URL } = config
 
 const allowedCors = [FRONTEND_URL]
 const DEFAULT_ALLOWED_METHODS = 'GET,HEAD,PUT,PATCH,POST,DELETE'
 
-module.exports = (req, res, next) => {
+const cors = (req, res, next) => {
   const { origin } = req.headers
   const requestHeaders = req.headers['access-control-request-headers']
   const { method } = req
@@ -23,3 +25,5 @@ module.exports = (req, res, next) => {
 
   next()
 }
+
+export default cors

--- a/src/shared/middlewares/limiter.js
+++ b/src/shared/middlewares/limiter.js
@@ -1,6 +1,8 @@
-const rateLimit = require('express-rate-limit')
+import rateLimit from 'express-rate-limit'
 
-module.exports.limiter = rateLimit({
+const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 100,
 })
+
+export default limiter

--- a/src/shared/middlewares/logger.js
+++ b/src/shared/middlewares/logger.js
@@ -1,17 +1,12 @@
-const expressWinston = require('express-winston')
-const winston = require('winston')
+import expressWinston from 'express-winston'
+import winston from 'winston'
 
-const requestLogger = expressWinston.logger({
+export const requestLogger = expressWinston.logger({
   transports: [new winston.transports.File({ filename: 'request.log' })],
   format: winston.format.json(),
 })
 
-const errorLogger = expressWinston.errorLogger({
+export const errorLogger = expressWinston.errorLogger({
   transports: [new winston.transports.File({ filename: 'error.log' })],
   format: winston.format.json(),
 })
-
-module.exports = {
-  errorLogger,
-  requestLogger,
-}

--- a/src/shared/middlewares/validation.js
+++ b/src/shared/middlewares/validation.js
@@ -1,7 +1,9 @@
-const { celebrate, Joi } = require('celebrate')
-const validator = require('validator')
+import { celebrate, Joi } from 'celebrate'
+import validator from 'validator'
 
-const { BAD_REQUEST } = require('../constants/response')
+import response from '../constants/response.js'
+
+const { BAD_REQUEST } = response
 
 const validationUrl = (value) => {
   if (validator.isURL(value)) {
@@ -10,7 +12,7 @@ const validationUrl = (value) => {
   return BAD_REQUEST.text
 }
 
-module.exports.addMovieValidation = celebrate({
+export const addMovieValidation = celebrate({
   body: Joi.object().keys({
     country: Joi.string().required(),
     director: Joi.string().required(),
@@ -25,19 +27,21 @@ module.exports.addMovieValidation = celebrate({
     nameEN: Joi.string().required(),
   }),
 })
-module.exports.deleteMovieValidation = celebrate({
+
+export const deleteMovieValidation = celebrate({
   params: Joi.object().keys({
     movieId: Joi.string().required().hex().length(24),
   }),
 })
-module.exports.signinValidation = celebrate({
+
+export const signinValidation = celebrate({
   body: Joi.object().keys({
     email: Joi.string().required().email(),
     password: Joi.string().required(),
   }),
 })
 
-module.exports.signupValidationd = celebrate({
+export const signupValidationd = celebrate({
   body: Joi.object().keys({
     name: Joi.string().required().min(2).max(30),
     email: Joi.string().required().email(),
@@ -45,7 +49,7 @@ module.exports.signupValidationd = celebrate({
   }),
 })
 
-module.exports.updateUserProfileValidation = celebrate({
+export const updateUserProfileValidation = celebrate({
   body: Joi.object().keys({
     name: Joi.string().required().min(2).max(30),
     email: Joi.string().required().email(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     // Environment Settings
     // See also https://aka.ms/tsconfig/module
     "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "NodeNext",
     "target": "esnext",
     // For nodejs:
     "lib": ["esnext"],


### PR DESCRIPTION
replace require() with import syntax, update module.exports to export default / named exports- add "type": "module" to package.json, update local imports with .js extensions, adjust __dirname usage for ESM compatibility

BREAKING CHANGE: project now uses ES Modules instead of CommonJS