### PR TITLE
refactor(auth): re-architect register route using Clean Architecture and add tests

### DIFF
--- a/src/app/dtos/AuthDTO.ts
+++ b/src/app/dtos/AuthDTO.ts
@@ -1,10 +1,13 @@
 import type z from 'zod'
 
 import type {
-  signinResponseSchema,
+  authResponseSchema,
   signinSchema,
+  signupSchema,
 } from '@infrastructure/http/modules/auth/auth.validation.js'
 
 export type TLoginBodyDto = z.infer<typeof signinSchema>
 
-export type TLoginResponseDto = z.infer<typeof signinResponseSchema>
+export type TRegisterBodyDto = z.infer<typeof signupSchema>
+
+export type TAuthResponseDto = z.infer<typeof authResponseSchema>

--- a/src/app/interfaces/repositories/IUserRepository.ts
+++ b/src/app/interfaces/repositories/IUserRepository.ts
@@ -1,5 +1,14 @@
 import type User from '@domain/entities/User.js'
 
-export default interface IUserRepository {
+export type TNewUser = Pick<User, 'email' | 'name' | 'passwordHash'>
+
+export interface IUserRepository {
   findUserByCredentials: (email: string) => Promise<User | null>
+  create: (user: TNewUser) => Promise<User>
 }
+
+export type ILoginUserRepository = Pick<
+  IUserRepository,
+  'findUserByCredentials'
+>
+export type IRegisterUserRepository = Pick<IUserRepository, 'create'>

--- a/src/app/interfaces/services/IHashService.ts
+++ b/src/app/interfaces/services/IHashService.ts
@@ -1,6 +1,8 @@
 export default interface IHashService {
-  hash: (data: string) => Promise<string>
+  generate: (data: string) => Promise<string>
   compare: (data: string, hash: string) => Promise<boolean>
 }
 
 export type THashComparerService = Pick<IHashService, 'compare'>
+
+export type THashGeneratorService = Pick<IHashService, 'generate'>

--- a/src/app/use-cases/auth/LocalAuth.ts
+++ b/src/app/use-cases/auth/LocalAuth.ts
@@ -1,13 +1,13 @@
 import InvalidCredentialsError from '@domain/errors/InvalidCredentialsError.js'
 
-import type IUserRepository from '@app/interfaces/repositories/IUserRepository.js'
+import type { ILoginUserRepository } from '@app/interfaces/repositories/IUserRepository.js'
 import type { THashComparerService } from '@app/interfaces/services/IHashService.js'
 import type { TTokenGenerateService } from '@app/interfaces/services/ITokenService.js'
 import type User from '@domain/entities/User.js'
 
 export default class LocalAuth {
   constructor(
-    private readonly userRepository: IUserRepository,
+    private readonly loginRepository: ILoginUserRepository,
     private readonly hashComparerService: THashComparerService,
     private readonly tokenGenerateService: TTokenGenerateService,
   ) {}
@@ -16,7 +16,7 @@ export default class LocalAuth {
     email: string,
     password: string,
   ): Promise<{ user: User; token: string }> {
-    const user = await this.userRepository.findUserByCredentials(email)
+    const user = await this.loginRepository.findUserByCredentials(email)
     if (!user) throw new InvalidCredentialsError()
     const isMatched = await this.hashComparerService.compare(
       password,

--- a/src/app/use-cases/auth/Register.ts
+++ b/src/app/use-cases/auth/Register.ts
@@ -1,0 +1,21 @@
+import PasswordHash from '@domain/value-objects/user/PasswordHash.js'
+
+import type { IRegisterUserRepository } from '@app/interfaces/repositories/IUserRepository.js'
+import type { THashGeneratorService } from '@app/interfaces/services/IHashService.js'
+import type User from '@domain/entities/User.js'
+
+export default class Register {
+  constructor(
+    private readonly registerRepository: IRegisterUserRepository,
+    private readonly hashGeneratorService: THashGeneratorService,
+  ) {}
+
+  async execute(name: string, email: string, password: string): Promise<User> {
+    const hash = await this.hashGeneratorService.generate(password)
+    return this.registerRepository.create({
+      name,
+      email,
+      passwordHash: new PasswordHash(hash),
+    })
+  }
+}

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -1,12 +1,11 @@
-import type IHashService from '@app/interfaces/services/IHashService.js'
-import type passwordHash from '@domain/value-objects/user/PasswordHash.js'
+import type PasswordHash from '@domain/value-objects/user/PasswordHash.js'
 
 export default class User {
   constructor(
     public readonly id: string,
     public readonly email: string,
     public readonly name: string,
-    public readonly passwordHash: passwordHash,
+    public readonly passwordHash: PasswordHash,
   ) {}
 
   public toJSON() {

--- a/src/domain/entities/types.ts
+++ b/src/domain/entities/types.ts
@@ -1,0 +1,1 @@
+export type TEntity = 'User'

--- a/src/domain/errors/BadRequestError.ts
+++ b/src/domain/errors/BadRequestError.ts
@@ -1,0 +1,10 @@
+import DomainError from './DomainError.js'
+
+export default class BadRequestError extends DomainError {
+  readonly code: string
+
+  constructor() {
+    super('Incorrect data provided')
+    this.code = `BAD_REQUEST`
+  }
+}

--- a/src/domain/errors/ConflictError.ts
+++ b/src/domain/errors/ConflictError.ts
@@ -1,0 +1,12 @@
+import DomainError from './DomainError.js'
+
+import type { TEntity } from '@domain/entities/types.js'
+
+export default class ConflictError extends DomainError {
+  readonly code: string
+
+  constructor(entityName: TEntity) {
+    super(`${entityName} already exists`)
+    this.code = `${entityName.toUpperCase()}.CONFLICT`
+  }
+}

--- a/src/domain/errors/NotFoundError.ts
+++ b/src/domain/errors/NotFoundError.ts
@@ -1,13 +1,12 @@
 import DomainError from './DomainError.js'
 
-type TEntity = 'User'
+import type { TEntity } from '@domain/entities/types.js'
 
 export default class NotFoundError extends DomainError {
   readonly code: string
 
   constructor(entityName: TEntity, entityId: string) {
-    const uppercaseCode = entityName
     super(`${entityName} with id ${entityId} was not found.`)
-    this.code = `${uppercaseCode.toUpperCase()}.NOT_FOUND`
+    this.code = `${entityName.toUpperCase()}.NOT_FOUND`
   }
 }

--- a/src/infrastructure/config/routes.ts
+++ b/src/infrastructure/config/routes.ts
@@ -10,10 +10,12 @@ const BASE_ROUTES = {
 
 export const AUTH_ROUTES = {
   signin: '/signin',
+  signup: '/signup',
 } as const
 
 export const API_ROUTES = {
   auth: {
     signin: `${BASE_ROUTES.auth}${AUTH_ROUTES.signin}`,
+    signup: `${BASE_ROUTES.auth}${AUTH_ROUTES.signup}`,
   },
 } as const satisfies TRoutesMap

--- a/src/infrastructure/constants/validation-responses.ts
+++ b/src/infrastructure/constants/validation-responses.ts
@@ -1,19 +1,26 @@
 const VALIDATION_MESSAGES = {
-  EMAIL: {
+  name: {
+    tooShort: 'Name must be at least 1 characters long',
+    tooLong: 'Name must be at least 30 characters short',
+    description: 'Name of the user',
+    example: 'John',
+  },
+  email: {
     invalidFormat: 'Incorrect email format',
     description: 'User email address used for authentication',
-    example: 'qwerty@qwerty.com',
+    example: 'john@example.com',
   },
-  PASSWORD: {
-    tooShort: 'Password must be at least 8 characters long',
+  password: {
+    validate:
+      'Password must be at least 8 characters long and include uppercase and lowercase letters, numbers, and special characters.',
     description: 'Secure user password',
     example: 'Secret_Password123',
   },
-  AUTH: {
+  auth: {
     idDescription: 'Unique identifier of the authenticated user',
     idExample: '65cb3d4f1a2b3c4d5e6f7a8b',
     emailDescription: 'Verified email address associated with the account',
-    emailExample: 'qwerty@qwerty.com',
+    emailExample: 'john@example.com',
     nameDescription: 'Name of the user',
     nameExample: 'John',
   },

--- a/src/infrastructure/http/middleware/errors/errorsHandler.ts
+++ b/src/infrastructure/http/middleware/errors/errorsHandler.ts
@@ -1,8 +1,9 @@
 import z from 'zod'
 
+import DomainError from '@domain/errors/DomainError.js'
 import response from '@infrastructure/constants/response.js'
 
-import handleZodError from './zodErrorHandler.js'
+import zodErrorHandler from './zodErrorsHandler.js'
 
 import type { ErrorRequestHandler } from 'express'
 
@@ -17,7 +18,12 @@ const errorHandler: ErrorRequestHandler = (e, _, res, next) => {
   }
 
   if (e instanceof z.ZodError) {
-    handleZodError(e, res)
+    zodErrorHandler(e, res)
+    return
+  }
+
+  if (e instanceof DomainError) {
+    res.status(404).send({ message: e.code })
     return
   }
 

--- a/src/infrastructure/http/middleware/errors/zodErrorsHandler.ts
+++ b/src/infrastructure/http/middleware/errors/zodErrorsHandler.ts
@@ -3,14 +3,14 @@ import HttpStatusCode from '@infrastructure/constants/https-status-code.js'
 import type { Response } from 'express'
 import type { z } from 'zod'
 
-const handleZodError = (error: z.ZodError, res: Response): void => {
+const zodErrorHandler = (e: z.ZodError, res: Response): void => {
   res.status(HttpStatusCode.BadRequest).json({
     status: 'ValidationError',
-    errors: error.issues.map((issue) => ({
+    errors: e.issues.map((issue) => ({
       field: issue.path.join('.'),
       message: issue.message,
     })),
   })
 }
 
-export default handleZodError
+export default zodErrorHandler

--- a/src/infrastructure/http/modules/auth/AuthController.ts
+++ b/src/infrastructure/http/modules/auth/AuthController.ts
@@ -1,11 +1,15 @@
 import HttpStatusCode from '@infrastructure/constants/https-status-code.js'
 
 import type LocalAuth from '@app/use-cases/auth/LocalAuth.js'
+import type Register from '@app/use-cases/auth/Register.js'
 
-import type { TLoginHandler } from './types.js'
+import type { TLoginHandler, TRegisterHandler } from './types.js'
 
 export default class AuthController {
-  constructor(private localAuth: LocalAuth) {}
+  constructor(
+    private readonly localAuth: LocalAuth,
+    private readonly register: Register,
+  ) {}
 
   loginByEmail: TLoginHandler = async (req, res, _) => {
     const { email, password } = req.body
@@ -19,5 +23,11 @@ export default class AuthController {
         sameSite: 'none',
       })
       .send(user)
+  }
+
+  registerUser: TRegisterHandler = async (req, res, next) => {
+    const { name, email, password } = req.body
+    const user = await this.register.execute(name, email, password)
+    res.status(HttpStatusCode.Created).send(user)
   }
 }

--- a/src/infrastructure/http/modules/auth/auth.docs.ts
+++ b/src/infrastructure/http/modules/auth/auth.docs.ts
@@ -1,7 +1,11 @@
 import { API_ROUTES } from '@infrastructure/config/routes.js'
 import HttpStatusCode from '@infrastructure/constants/https-status-code.js'
 
-import { signinResponseSchema, signinSchema } from './auth.validation.js'
+import {
+  authResponseSchema,
+  signinSchema,
+  signupSchema,
+} from './auth.validation.js'
 
 import type { ZodOpenApiPathItemObject } from 'zod-openapi'
 
@@ -25,7 +29,7 @@ const authRoutesJson: Record<TAuthFullRoutesValues, ZodOpenApiPathItemObject> =
           [HttpStatusCode.Ok]: {
             description: 'Successfully authenticated. Returns access token.',
             content: {
-              'application/json': { schema: signinResponseSchema },
+              'application/json': { schema: authResponseSchema },
             },
           },
           [HttpStatusCode.BadRequest]: {
@@ -34,6 +38,32 @@ const authRoutesJson: Record<TAuthFullRoutesValues, ZodOpenApiPathItemObject> =
           },
           [HttpStatusCode.Unauthorized]: {
             description: 'Unauthorized. Invalid email or password provided.',
+          },
+        },
+      },
+    },
+    [API_ROUTES.auth.signup]: {
+      post: {
+        tags: ['Auth'],
+        summary: 'User Registration',
+        description:
+          'Registers a new user with their credentials (e.g., name, email, and password) and returns the created user data or a JWT access token.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: signupSchema },
+          },
+        },
+        responses: {
+          [HttpStatusCode.Created]: {
+            description: 'User successfully registered.',
+            content: {
+              'application/json': { schema: authResponseSchema },
+            },
+          },
+          [HttpStatusCode.BadRequest]: {
+            description:
+              'Validation Error. Sent when input data fails schema verification or email is already taken.',
           },
         },
       },

--- a/src/infrastructure/http/modules/auth/auth.validation.ts
+++ b/src/infrastructure/http/modules/auth/auth.validation.ts
@@ -1,31 +1,44 @@
+import validator from 'validator'
 import z from 'zod'
 
 import VALIDATION_MESSAGES from '@infrastructure/constants/validation-responses.js'
 
-const { EMAIL, PASSWORD, AUTH } = VALIDATION_MESSAGES
+const { email, password, name, auth } = VALIDATION_MESSAGES
 
 export const signinSchema = z.object({
-  email: z.email(EMAIL.invalidFormat).meta({
-    description: EMAIL.description,
-    example: EMAIL.example,
+  email: z.email(email.invalidFormat).meta({
+    description: email.description,
+    example: email.example,
   }),
-  password: z.string().min(8, PASSWORD.tooShort).meta({
-    description: PASSWORD.description,
-    example: PASSWORD.example,
+  password: z
+    .string()
+    .refine((value) => validator.isStrongPassword(value), {
+      message: password.validate,
+    })
+    .meta({
+      description: password.description,
+      example: password.example,
+    }),
+})
+
+export const signupSchema = signinSchema.extend({
+  name: z.string().min(1, name.tooShort).max(30, name.tooLong).meta({
+    description: name.description,
+    example: name.example,
   }),
 })
 
-export const signinResponseSchema = z.object({
+export const authResponseSchema = z.object({
   id: z.string().meta({
-    description: AUTH.idDescription,
-    example: AUTH.idExample,
+    description: auth.idDescription,
+    example: auth.idExample,
   }),
   email: z.string().meta({
-    description: AUTH.emailDescription,
-    example: AUTH.emailExample,
+    description: auth.emailDescription,
+    example: auth.emailExample,
   }),
   name: z.string().meta({
-    description: AUTH.nameDescription,
-    example: AUTH.nameExample,
+    description: auth.nameDescription,
+    example: auth.nameExample,
   }),
 })

--- a/src/infrastructure/http/modules/auth/authRoutes.ts
+++ b/src/infrastructure/http/modules/auth/authRoutes.ts
@@ -18,7 +18,11 @@ const createAuthRoutes = (
     authValidation.signin,
     authController.loginByEmail,
   )
-  router.post('/signup', signupValidationd, createUser)
+  router.post(
+    AUTH_ROUTES.signup,
+    authValidation.signup,
+    authController.registerUser,
+  )
   router.get('signout', logout)
   return router
 }

--- a/src/infrastructure/http/modules/auth/authValidations.ts
+++ b/src/infrastructure/http/modules/auth/authValidations.ts
@@ -1,10 +1,11 @@
-import { signinSchema } from './auth.validation.js'
+import { signinSchema, signupSchema } from './auth.validation.js'
 import validateBody from '../../middleware/validation-zod.middleware.js'
 
 import type { TAuthValidations } from './types.js'
 
 const authValidations: TAuthValidations = {
   signin: validateBody(signinSchema),
+  signup: validateBody(signupSchema),
 }
 
 export default authValidations

--- a/src/infrastructure/http/modules/auth/types.ts
+++ b/src/infrastructure/http/modules/auth/types.ts
@@ -1,6 +1,10 @@
 import type { RequestHandler } from 'express'
 
-import type { TLoginBodyDto, TLoginResponseDto } from '@app/dtos/UserDTO.js'
+import type {
+  TAuthResponseDto,
+  TLoginBodyDto,
+  TRegisterBodyDto,
+} from '@app/dtos/AuthDTO.js'
 import type { API_ROUTES, AUTH_ROUTES } from '@infrastructure/config/routes.js'
 
 export type TAuthFullRoutesValues =
@@ -12,10 +16,16 @@ export type TAuthRoutess = (typeof AUTH_ROUTES)[keyof typeof AUTH_ROUTES]
 
 export type TAuthValidations = Record<TAuthRoutes, RequestHandler>
 
-type TLoginParams = Record<string, never>
+type TAuthParams = Record<string, never>
 
 export type TLoginHandler = RequestHandler<
-  TLoginParams,
-  TLoginResponseDto,
+  TAuthParams,
+  TAuthResponseDto,
   TLoginBodyDto
+>
+
+export type TRegisterHandler = RequestHandler<
+  TAuthParams,
+  TAuthResponseDto,
+  TRegisterBodyDto
 >

--- a/src/infrastructure/http/server.ts
+++ b/src/infrastructure/http/server.ts
@@ -6,7 +6,7 @@ import helmet from 'helmet'
 import rateLimitMiddleware from '@infrastructure/http/middleware/rate-limit.middleware.js'
 
 import cors from './middleware/cors.middleware.js'
-import errorHandler from './middleware/errors/errorHandler.js'
+import errorsHandler from './middleware/errors/errorsHandler.js'
 import { errorLogger, requestLogger } from './middleware/logger.middleware.js'
 
 import type { Express } from 'express'
@@ -39,7 +39,7 @@ export default class App implements IApp {
     this.express.use(this.appRouter.requestHandler)
     this.express.use(errorLogger)
     this.express.use(errors())
-    this.express.use(errorHandler)
+    this.express.use(errorsHandler)
   }
 
   async start(): Promise<void> {

--- a/src/infrastructure/persistence/mongodb/UserModel.ts
+++ b/src/infrastructure/persistence/mongodb/UserModel.ts
@@ -1,11 +1,6 @@
 import { model, Schema } from 'mongoose'
-import validator from 'validator'
-
-import response from '../../constants/response.js'
 
 import type { HydratedDocument, InferSchemaType } from 'mongoose'
-
-const { BAD_REQUEST } = response
 
 const userSchema = new Schema(
   {
@@ -18,17 +13,9 @@ const userSchema = new Schema(
       type: String,
       required: true,
       select: false,
-      validate: {
-        validator(value: string) {
-          return validator.isStrongPassword(value)
-        },
-        message: BAD_REQUEST.text,
-      },
     },
     name: {
       type: String,
-      minlength: 2,
-      maxlength: 30,
       required: true,
     },
   },

--- a/src/infrastructure/persistence/repositories/MongooseUserRepository.ts
+++ b/src/infrastructure/persistence/repositories/MongooseUserRepository.ts
@@ -1,7 +1,14 @@
+import { mongo, MongooseError } from 'mongoose'
+
 import User from '@domain/entities/User.js'
+import BadRequestError from '@domain/errors/BadRequestError.js'
+import ConflictError from '@domain/errors/ConflictError.js'
 import PasswordHash from '@domain/value-objects/user/PasswordHash.js'
 
-import type IUserRepository from '@app/interfaces/repositories/IUserRepository.js'
+import type {
+  IUserRepository,
+  TNewUser,
+} from '@app/interfaces/repositories/IUserRepository.js'
 
 import type { TUserModel } from '../mongodb/UserModel.js'
 
@@ -17,5 +24,32 @@ export default class MongooseUserRepository implements IUserRepository {
       userData.name,
       new PasswordHash(userData.password),
     )
+  }
+
+  async create(newUser: TNewUser): Promise<User> {
+    try {
+      const userData = await this.userModel.create({
+        name: newUser.name,
+        email: newUser.email,
+        password: newUser.passwordHash.value,
+      })
+      return new User(
+        userData._id.toString(),
+        userData.email,
+        userData.name,
+        new PasswordHash(userData.password),
+      )
+    } catch (e) {
+      if (e instanceof mongo.MongoServerError && e.code === 11000) {
+        throw new ConflictError('User')
+      }
+      if (
+        e instanceof MongooseError &&
+        (e.name === 'CastError' || e.name === 'ValidationError')
+      ) {
+        throw new BadRequestError()
+      }
+      throw e
+    }
   }
 }

--- a/src/infrastructure/services/BcryptHashService.ts
+++ b/src/infrastructure/services/BcryptHashService.ts
@@ -5,7 +5,7 @@ import type IHashService from '@app/interfaces/services/IHashService.js'
 export default class BcryptHashService implements IHashService {
   constructor(private readonly saltRounds: number) {}
 
-  async hash(data: string): Promise<string> {
+  async generate(data: string): Promise<string> {
     return bcrypt.hash(data, this.saltRounds)
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { createTerminus } from '@godaddy/terminus'
 import swaggerUi from 'swagger-ui-express'
 
 import LocalAuth from '@app/use-cases/auth/LocalAuth.js'
+import Register from '@app/use-cases/auth/Register.js'
 import getTerminusOptions from '@infrastructure/config/terminus.config.js'
 import openApiDocumentation from '@infrastructure/http/apiDocs/index.docs.js'
 import AuthController from '@infrastructure/http/modules/auth/AuthController.js'
@@ -40,7 +41,8 @@ function bootstrap() {
     hashService,
     tokenService,
   )
-  const authController = new AuthController(localAuth)
+  const register = new Register(mongooseUserRepository, hashService)
+  const authController = new AuthController(localAuth, register)
   const authRoutes = createAuthRoutes(authValidations, authController)
 
   const appRouter = new AppRouter(docRoutes, authRoutes)

--- a/tests/integration/repositories/MongooseUserRepository.test.ts
+++ b/tests/integration/repositories/MongooseUserRepository.test.ts
@@ -1,6 +1,8 @@
 import { MongoMemoryServer } from 'mongodb-memory-server'
+import { MongooseError } from 'mongoose'
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -9,13 +11,20 @@ import {
   vi,
 } from 'vitest'
 
+import User from '@domain/entities/User.js'
+import BadRequestError from '@domain/errors/BadRequestError.js'
+import ConflictError from '@domain/errors/ConflictError.js'
+import PasswordHash from '@domain/value-objects/user/PasswordHash.js'
 import UserModel from '@infrastructure/persistence/mongodb/UserModel.js'
 import MongooseUserRepository from '@infrastructure/persistence/repositories/MongooseUserRepository.js'
 import MongooseService from '@infrastructure/services/MongooseService.js'
 
 import type { MockInstance } from 'vitest'
 
-import type IUserRepository from '@app/interfaces/repositories/IUserRepository.js'
+import type {
+  IUserRepository,
+  TNewUser,
+} from '@app/interfaces/repositories/IUserRepository.js'
 import type { IDBService } from '@app/interfaces/services/IDBService.js'
 
 describe('MongooseUserRepository', () => {
@@ -23,6 +32,11 @@ describe('MongooseUserRepository', () => {
   let mongooseService: IDBService
   let userRepository: IUserRepository
   let consoleSpies: MockInstance[] = []
+  const fakeNewUser: TNewUser = {
+    email: 'test@example.com',
+    name: 'John Doe',
+    passwordHash: new PasswordHash('Hashed_password_123'),
+  }
 
   beforeAll(async () => {
     consoleSpies = [
@@ -45,22 +59,20 @@ describe('MongooseUserRepository', () => {
   })
 
   beforeEach(async () => {
+    await UserModel.create({ ...fakeNewUser, password: 'Hashed_password_123' })
+  })
+
+  afterEach(async () => {
     await UserModel.deleteMany({})
   })
 
   it('should be successfully find user by email and return domain entity', async () => {
-    await UserModel.create({
-      email: 'test@example.com',
-      name: 'John Doe',
-      password: 'Hashed_password_123,',
-    })
-
     const user = await userRepository.findUserByCredentials('test@example.com')
 
     expect(user).not.toBeNull()
     expect(user?.email).toBe('test@example.com')
     expect(user?.name).toBe('John Doe')
-    expect(user?.passwordHash.value).toBe('Hashed_password_123,')
+    expect(user?.passwordHash.value).toBe('Hashed_password_123')
   })
 
   it('should be return null if user not found', async () => {
@@ -68,5 +80,30 @@ describe('MongooseUserRepository', () => {
       'notfound@example.com',
     )
     expect(user).toBeNull()
+  })
+
+  it('should be throw ConflictError error if user already exists', async () => {
+    const action = userRepository.create(fakeNewUser)
+    await expect(action).rejects.toThrow(ConflictError)
+  })
+
+  it('should throw BadRequestError if name violates minlength constraint', async () => {
+    const validationError = Object.create(MongooseError.prototype, {
+      name: { value: 'ValidationError', writable: true },
+      message: { value: 'Mongoose validation failed', writable: true },
+    })
+    const spy = vi
+      .spyOn(UserModel, 'create')
+      .mockRejectedValueOnce(validationError)
+    await UserModel.deleteMany({})
+    const action = userRepository.create(fakeNewUser)
+    await expect(action).rejects.toThrow(BadRequestError)
+    spy.mockRestore()
+  })
+
+  it('should be create new user', async () => {
+    await UserModel.deleteMany({})
+    const action = userRepository.create(fakeNewUser)
+    await expect(action).resolves.toBeInstanceOf(User)
   })
 })

--- a/tests/integration/services/BcryptHashService.test.ts
+++ b/tests/integration/services/BcryptHashService.test.ts
@@ -8,7 +8,7 @@ describe('check BcryptHashService', () => {
   const password = 'my-secret-password'
 
   it('should successfully hash a string and verify it', async () => {
-    const hash = await hashService.hash(password)
+    const hash = await hashService.generate(password)
     expect(hash).toBeDefined()
     expect(hash).not.toBe(password)
 

--- a/tests/unit/infrastructure/mongoose.unit.test.ts
+++ b/tests/unit/infrastructure/mongoose.unit.test.ts
@@ -2,7 +2,7 @@ import mongoose from 'mongoose'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import config from '@infrastructure/config/env.js'
-import Mongoose from '@infrastructure/services/MongooseService.js'
+import MongooseService from '@infrastructure/services/MongooseService.js'
 
 import type { IDBService } from '@app/interfaces/services/IDBService.js'
 
@@ -33,21 +33,21 @@ vi.mock('mongoose', () => ({
 }))
 
 describe('chech mongoose', () => {
-  let fakeMongoose: IDBService
+  let fakeMongooseService: IDBService
 
   beforeEach(() => {
-    fakeMongoose = new Mongoose(config.MONGODB_URI)
+    fakeMongooseService = new MongooseService(config.MONGODB_URI)
     vi.spyOn(console, 'info').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   describe('check connect', () => {
     it('call with correct uri', async () => {
-      await fakeMongoose.connect()
+      await fakeMongooseService.connect()
       expect(mongoose.connect).toHaveBeenCalledWith(config.MONGODB_URI)
     })
     it('call connection.on', async () => {
-      await fakeMongoose.connect()
+      await fakeMongooseService.connect()
       expect(mongoose.connection.on).toHaveBeenCalledWith(
         'connecting',
         expect.any(Function),
@@ -85,12 +85,12 @@ describe('chech mongoose', () => {
 
   describe('check connection', () => {
     it('should return false', async () => {
-      const result = await fakeMongoose.checkConnection()
+      const result = await fakeMongooseService.checkConnection()
       expect(result).toBe(false)
     })
     it('should return true if connected and ping success', async () => {
       mockContext.readyState = 1
-      const result = await fakeMongoose.checkConnection()
+      const result = await fakeMongooseService.checkConnection()
       await expect(mongoose.connection.db?.admin().ping()).resolves.toEqual({
         ok: 1,
       })
@@ -99,7 +99,7 @@ describe('chech mongoose', () => {
     it('should return false if ping fails', async () => {
       mockContext.readyState = 1
       mockContext.ping.mockRejectedValue(new Error())
-      const result = await fakeMongoose.checkConnection()
+      const result = await fakeMongooseService.checkConnection()
       await expect(mongoose.connection.db?.admin().ping()).rejects.toThrow()
       expect(result).toBe(false)
     })

--- a/tests/unit/use-case/auth/localAuth.unut.test.ts
+++ b/tests/unit/use-case/auth/localAuth.unut.test.ts
@@ -1,39 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import LocalAuth from '@app/use-cases/auth/LocalAuth.js'
+import User from '@domain/entities/User.js'
 import InvalidCredentialsError from '@domain/errors/InvalidCredentialsError.js'
+import PasswordHash from '@domain/value-objects/user/PasswordHash.js'
 
 import type { Mocked } from 'vitest'
 
-import type { TLoginBodyDto } from '@app/dtos/UserDTO.js'
-import type IUserRepository from '@app/interfaces/repositories/IUserRepository.js'
+import type { TAuthResponseDto, TLoginBodyDto } from '@app/dtos/AuthDTO.js'
+import type { ILoginUserRepository } from '@app/interfaces/repositories/IUserRepository.js'
 import type { THashComparerService } from '@app/interfaces/services/IHashService.js'
 import type { TTokenGenerateService } from '@app/interfaces/services/ITokenService.js'
-import type User from '@domain/entities/User.js'
 
 describe('check local auth', () => {
-  let userRepository: Mocked<IUserRepository>
+  let loginRepository: Mocked<ILoginUserRepository>
   let fakeHashComparerService: Mocked<THashComparerService>
   let fakeGenerateTokenService: Mocked<TTokenGenerateService>
   let localAuth: LocalAuth
   const fakeLoginBodyDto: TLoginBodyDto = {
-    email: 'qwerty@qwerty.com',
-    password: 'string',
+    email: 'test@example.com',
+    password: 'Hashed_password_123',
   }
-  const fakeUser: User = {
-    email: 'qwerty@qwerty.com',
-    id: 'string',
-    passwordHash: { value: 'string' },
-    name: 'string',
-    toJSON: vi.fn(),
-  }
-  const fakeResult: { user: Partial<User>; token: string } = {
+  const fakeUser = new User(
+    '1',
+    'test@example.com',
+    'John Doe',
+    new PasswordHash('Hashed_password_123'),
+  )
+
+  const fakeResult: { user: TAuthResponseDto; token: string } = {
     user: fakeUser,
     token: 'jwt',
   }
 
   beforeEach(() => {
-    userRepository = {
+    loginRepository = {
       findUserByCredentials: vi.fn().mockResolvedValue(fakeUser),
     }
     fakeHashComparerService = {
@@ -44,7 +45,7 @@ describe('check local auth', () => {
     }
 
     localAuth = new LocalAuth(
-      userRepository,
+      loginRepository,
       fakeHashComparerService,
       fakeGenerateTokenService,
     )
@@ -59,14 +60,14 @@ describe('check local auth', () => {
       fakeLoginBodyDto.password,
     )
     expect(result).toStrictEqual(fakeResult)
-    expect(userRepository.findUserByCredentials).toHaveBeenCalledWith(
+    expect(loginRepository.findUserByCredentials).toHaveBeenCalledWith(
       fakeLoginBodyDto.email,
     )
     expect(fakeHashComparerService.compare).toHaveBeenCalledTimes(1)
     expect(fakeGenerateTokenService.generate).toHaveBeenCalledTimes(1)
   })
   it('should throw when user not found', async () => {
-    userRepository.findUserByCredentials.mockResolvedValue(null)
+    loginRepository.findUserByCredentials.mockResolvedValue(null)
     const action = localAuth.execute(
       fakeLoginBodyDto.email,
       fakeLoginBodyDto.password,

--- a/tests/unit/use-case/auth/register.unut.test.ts
+++ b/tests/unit/use-case/auth/register.unut.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Register from '@app/use-cases/auth/Register.js'
+import User from '@domain/entities/User.js'
+import InvalidCredentialsError from '@domain/errors/InvalidCredentialsError.js'
+import PasswordHash from '@domain/value-objects/user/PasswordHash.js'
+
+import type { Mocked } from 'vitest'
+
+import type {
+  TAuthResponseDto,
+  TLoginBodyDto,
+  TRegisterBodyDto,
+} from '@app/dtos/AuthDTO.js'
+import type { IRegisterUserRepository } from '@app/interfaces/repositories/IUserRepository.js'
+import type {
+  THashComparerService,
+  THashGeneratorService,
+} from '@app/interfaces/services/IHashService.js'
+import type { TTokenGenerateService } from '@app/interfaces/services/ITokenService.js'
+
+describe('check register', () => {
+  let registerRepository: Mocked<IRegisterUserRepository>
+  let fakeHashGenerateService: Mocked<THashGeneratorService>
+  let register: Register
+  const fakeRegisterBodyDto: TRegisterBodyDto = {
+    name: 'John Doe',
+    email: 'test@example.com',
+    password: 'password_123',
+  }
+  const fakeUser = new User(
+    '1',
+    'test@example.com',
+    'John Doe',
+    new PasswordHash('Hashed_password_123'),
+  )
+
+  const fakeResult: User = fakeUser
+
+  beforeEach(() => {
+    registerRepository = {
+      create: vi.fn().mockResolvedValue(fakeUser),
+    }
+    fakeHashGenerateService = {
+      generate: vi.fn().mockResolvedValue('Hashed_password_123'),
+    }
+
+    register = new Register(registerRepository, fakeHashGenerateService)
+
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('should register user', async () => {
+    const result = await register.execute(
+      fakeRegisterBodyDto.name,
+      fakeRegisterBodyDto.email,
+      fakeRegisterBodyDto.password,
+    )
+    expect(result).toStrictEqual(fakeResult)
+    expect(registerRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: fakeRegisterBodyDto.name,
+        email: fakeRegisterBodyDto.email,
+        passwordHash: expect.objectContaining({
+          value: 'Hashed_password_123',
+        }),
+      }),
+    )
+    expect(fakeHashGenerateService.generate).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
- Add OpenAPI/Swagger documentation and input/output Register DTOs
- Implement RegisterUseCase, User domain entity, and PasswordHash VO
- Decouple database layer via MongoUserRepository - Integrate domain-driven error handling for existing users
- Add comprehensive unit and integration tests for use case and repository layers